### PR TITLE
quieten byte compiler

### DIFF
--- a/map-progress-cl.el
+++ b/map-progress-cl.el
@@ -61,5 +61,6 @@ There may be only one SEQUENCE.  Also see `make-progress-reporter'.
 (provide 'map-progress-cl)
 ;; Local Variables:
 ;; indent-tabs-mode: nil
+;; byte-compile-warnings: (not cl-functions)
 ;; End:
 ;;; map-progress.el ends here


### PR DESCRIPTION
purpose: to make package.el install go smoothly
